### PR TITLE
Reuse has-password? from the handin server in the status server

### DIFF
--- a/handin-server/main.rkt
+++ b/handin-server/main.rkt
@@ -11,6 +11,7 @@
          "private/run-status.rkt"
          "private/reloadable.rkt"
          "private/hooker.rkt"
+         "private/userdb.rkt"
          (prefix-in web: "web-status-server.rkt")
          ;; this sets some global parameter values, and this needs
          ;; to be done in the main thread, rather than later in a
@@ -439,34 +440,6 @@
     (filter values (map (lambda (d f)
                           (and (memq f (get-conf 'user-fields)) d))
                         all-data (get-conf 'extra-fields)))))
-
-(define crypt
-  (let ([c #f] [sema (make-semaphore 1)])
-    ;; use only when needed so it doesn't blow up on non-unix platforms
-    (lambda (passwd salt)
-      (unless c (set! c (dynamic-require 'ffi/crypt 'crypt)))
-      ;; crypt is not reentrant
-      (call-with-semaphore sema
-                           (lambda () (bytes->string/utf-8 (c passwd salt)))))))
-(define ((make-has-password? error*) raw md5 passwords)
-  (define (good? passwd)
-    (define (bad-password msg)
-      (log-line "ERROR: ~a -- ~s" msg passwd)
-      (error* "bad password in user database"))
-    (cond [(string? passwd) (equal? md5 passwd)]
-          [(and (list? passwd) (= 2 (length passwd))
-                (symbol? (car passwd)) (string? (cadr passwd)))
-           (case (car passwd)
-             [(plaintext) (equal? raw (cadr passwd))]
-             [(unix)
-              (let ([salt (regexp-match #rx"^([$][^$]+[$][^$]+[$]|..)"
-                                        (cadr passwd))])
-                (unless salt (bad-password "badly formatted unix password"))
-                (equal? (crypt raw (car salt)) (cadr passwd)))]
-             [else (bad-password "bad password type in user database")])]
-          [else (bad-password "bad password value in user database")]))
-  (or (member md5 passwords) ; very cheap search first
-      (ormap good? passwords)))
 
 (define has-password? (make-has-password? error*))
 

--- a/handin-server/main.rkt
+++ b/handin-server/main.rkt
@@ -448,7 +448,7 @@
       ;; crypt is not reentrant
       (call-with-semaphore sema
                            (lambda () (bytes->string/utf-8 (c passwd salt)))))))
-(define (has-password? raw md5 passwords)
+(define ((make-has-password? error*) raw md5 passwords)
   (define (good? passwd)
     (define (bad-password msg)
       (log-line "ERROR: ~a -- ~s" msg passwd)
@@ -467,6 +467,8 @@
           [else (bad-password "bad password value in user database")]))
   (or (member md5 passwords) ; very cheap search first
       (ormap good? passwords)))
+
+(define has-password? (make-has-password? error*))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/handin-server/private/userdb.rkt
+++ b/handin-server/private/userdb.rkt
@@ -1,0 +1,33 @@
+#lang racket/base
+
+(require "logger.rkt")
+
+(define crypt
+  (let ([c #f] [sema (make-semaphore 1)])
+    ;; use only when needed so it doesn't blow up on non-unix platforms
+    (lambda (passwd salt)
+      (unless c (set! c (dynamic-require 'ffi/crypt 'crypt)))
+      ;; crypt is not reentrant
+      (call-with-semaphore sema
+                           (lambda () (bytes->string/utf-8 (c passwd salt)))))))
+
+(provide make-has-password?)
+(define ((make-has-password? error*) raw md5 passwords)
+  (define (good? passwd)
+    (define (bad-password msg)
+      (log-line "ERROR: ~a -- ~s" msg passwd)
+      (error* "bad password in user database"))
+    (cond [(string? passwd) (equal? md5 passwd)]
+          [(and (list? passwd) (= 2 (length passwd))
+                (symbol? (car passwd)) (string? (cadr passwd)))
+           (case (car passwd)
+             [(plaintext) (equal? raw (cadr passwd))]
+             [(unix)
+              (let ([salt (regexp-match #rx"^([$][^$]+[$][^$]+[$]|..)"
+                                        (cadr passwd))])
+                (unless salt (bad-password "badly formatted unix password"))
+                (equal? (crypt raw (car salt)) (cadr passwd)))]
+             [else (bad-password "bad password type in user database")])]
+          [else (bad-password "bad password value in user database")]))
+  (or (member md5 passwords) ; very cheap search first
+      (ormap good? passwords)))


### PR DESCRIPTION
The first two commits refactor the handin server to allow reuse of the `has-password?` function. The last commit replaces the password checking in the status server by call to that function. My goal is to bundle password checking in one place in order to uniformly extend it in a future pull request.
