### PR TITLE
Support discourse authentification

### DIFF
--- a/handin-server/main.rkt
+++ b/handin-server/main.rkt
@@ -347,9 +347,6 @@
       "users.rktd"))
    orig-custodian))
 
-(define (get-user-data username)
-  (get-preference (string->symbol username) (lambda () #f) 'timestamp
-                  "users.rktd"))
 (define (check-field value field-re field-name field-desc)
   (unless (cond [(or (string? field-re) (regexp? field-re))
                  (regexp-match field-re value)]

--- a/handin-server/private/config.rkt
+++ b/handin-server/private/config.rkt
@@ -94,6 +94,7 @@
     [(log-output)              (values #t                    id           )]
     [(log-file)                (values "log"                 path/false   )]
     [(web-log-file)            (values #f                    path/false   )]
+    [(discourse-config-file)   (values #f                    path/false   )]
     [(extra-fields)
      (values '(("Full Name" #f #f)
                ("ID#" #f #f)

--- a/handin-server/private/userdb.rkt
+++ b/handin-server/private/userdb.rkt
@@ -82,7 +82,7 @@
                                 (hash-ref user (string->symbol (car extra-field)))))))))]
          [data (cached 2000.0 fetch-data)])
     (lambda (username)
-      (hash-ref (data) username))))
+      (hash-ref (data) username #f))))
 
 ;; authenticate username/password with discourse
 (define (has-password/discourse? username password)

--- a/handin-server/private/userdb.rkt
+++ b/handin-server/private/userdb.rkt
@@ -78,7 +78,10 @@
 
 ;; authenticate username/password with discourse
 (define (has-password/discourse? username password)
-  (discourse "/admin/course/auth.json" (alist->form-urlencoded `((user . ,username) (password . ,password)))))
+  (hash-ref (discourse "/admin/course/auth.json"
+                       (alist->form-urlencoded `((user . ,username)
+                                                 (password . ,password))))
+            'success))
 
 (define crypt
   (let ([c #f] [sema (make-semaphore 1)])

--- a/handin-server/private/userdb.rkt
+++ b/handin-server/private/userdb.rkt
@@ -1,6 +1,18 @@
 #lang racket/base
 
-(require "logger.rkt")
+(require racket/file
+         "logger.rkt"
+         "config.rkt")
+
+;; Acess user data for a user.
+(provide get-user-data)
+(define get-user-data
+  (let ([users-file (build-path server-dir "users.rktd")])
+    (unless (file-exists? users-file)
+      (log-line "WARNING: users file missing on startup: ~a" users-file))
+    (lambda (user)
+      (and user (get-preference (string->symbol user) (lambda () #f) 'timestamp
+                                users-file)))))
 
 (define crypt
   (let ([c #f] [sema (make-semaphore 1)])

--- a/handin-server/private/userdb.rkt
+++ b/handin-server/private/userdb.rkt
@@ -9,7 +9,11 @@
 
 ;; Acess user data for a user.
 (provide get-user-data)
-(define get-user-data
+(define (get-user-data user)
+  (or (get-user-data/local user)
+      (get-user-data/discourse user)))
+
+(define get-user-data/local
   (let ([users-file (build-path server-dir "users.rktd")])
     (unless (file-exists? users-file)
       (log-line "WARNING: users file missing on startup: ~a" users-file))
@@ -112,6 +116,8 @@
                                         (cadr passwd))])
                 (unless salt (bad-password "badly formatted unix password"))
                 (equal? (crypt raw (car salt)) (cadr passwd)))]
+             [(discourse)
+              (has-password/discourse? (cadr passwd) raw)]
              [else (bad-password "bad password type in user database")])]
           [else (bad-password "bad password value in user database")]))
   (or (member md5 passwords) ; very cheap search first

--- a/handin-server/private/userdb.rkt
+++ b/handin-server/private/userdb.rkt
@@ -67,11 +67,15 @@
 (define get-user-data/discourse
   (let* ([fetch-data
           (lambda ()
-            (for/hash ([user (hash-ref (discourse "/admin/course/dump.json") 'users)])
-              (values (hash-ref user 'username)
-                      (cons (list 'discourse (hash-ref user 'username))
-                            (for/list ([extra-field (get-conf 'extra-fields)])
-                              (hash-ref user (string->symbol (car extra-field))))))))]
+            (let* ([response (discourse "/admin/course/dump.json")]
+                   [users (and response
+                               (hash-ref response 'success)
+                               (hash-ref response 'users))])
+              (for/hash ([user users])
+                (values (hash-ref user 'username)
+                        (cons (list 'discourse (hash-ref user 'username))
+                              (for/list ([extra-field (get-conf 'extra-fields)])
+                                (hash-ref user (string->symbol (car extra-field)))))))))]
          [data (cached 2000.0 fetch-data)])
     (lambda (username)
       (hash-ref (data) username))))

--- a/handin-server/private/userdb.rkt
+++ b/handin-server/private/userdb.rkt
@@ -67,8 +67,11 @@
 (define get-user-data/discourse
   (let* ([fetch-data
           (lambda ()
-            (for/hasheq ([user (hash-ref (discourse "/admin/course/dump.json") 'users)])
-              (values (string->symbol (hash-ref user 'username)) user)))]
+            (for/hash ([user (hash-ref (discourse "/admin/course/dump.json") 'users)])
+              (values (hash-ref user 'username)
+                      (cons (list 'discourse (hash-ref user 'username))
+                            (for/list ([extra-field (get-conf 'extra-fields)])
+                              (hash-ref user (string->symbol (car extra-field))))))))]
          [data (cached 2000.0 fetch-data)])
     (lambda (username)
       (hash-ref (data) username))))

--- a/handin-server/web-status-server.rkt
+++ b/handin-server/web-status-server.rkt
@@ -55,15 +55,6 @@
       (make-page-ext-template title body)
       (make-page-simple title body)))
 
-;; Acess user data for a user.
-(define get-user-data
-  (let ([users-file (build-path server-dir "users.rktd")])
-    (unless (file-exists? users-file)
-      (log-line "WARNING: users file missing on startup: ~a" users-file))
-    (lambda (user)
-      (and user (get-preference (string->symbol user) (lambda () #f) 'timestamp
-                                users-file)))))
-
 ;; Make path relative to server directory.
 (define (relativize-path p)
   (path->string (find-relative-path (normalize-path server-dir) p)))


### PR DESCRIPTION
If a user is not found in users.rktd, we talk to a Discourse instance to authenticate the user and fetch the extra-fields.

I don't know how the "register new users" and "change user data" features of the handin-client interact with this. Best disable them.
