### PR TITLE
Compare paths in platform independent way.

### DIFF
--- a/handin-server/web-status-server.rkt
+++ b/handin-server/web-status-server.rkt
@@ -260,14 +260,14 @@ Tutor: ivan_the_terrible")
                   [(name) (path->string name)]
                   [(check) (and (pair? elts) (car elts))])
       (if (null? elts)
-          ;; must be rooted in a submission directory (why build-path instead
-          ;; of using `path'? -- because path will have a trailing slash)
-          (member (build-path base name)
-                  (cond
-                   [(and allow-active? allow-inactive?) (get-conf 'all-dirs)]
-                   [allow-inactive? (get-conf 'inactive-dirs)]
-                   [allow-active? (get-conf 'active-dirs)]
-                   [else null]))
+          ;; must be rooted in a submission directory
+          (member (explode-path path)
+                  (map explode-path
+                       (cond
+                         [(and allow-active? allow-inactive?) (get-conf 'all-dirs)]
+                         [allow-inactive? (get-conf 'inactive-dirs)]
+                         [allow-active? (get-conf 'active-dirs)]
+                         [else null])))
           (and (cond [(eq? '* check) #t]
                      [(regexp? check) (regexp-match? check name)]
                      [(string? check)


### PR DESCRIPTION
This commit allows platform independent config.rktd files.

Before this change, the submission directories needed to use the path
separator convention of the platform that the handin server should run
on. With this change, a config.rktd can use either forward or backward
slash and should work on all platforms.
