### PR TITLE
Revise score outputs in status server

### DIFF
--- a/handin-server/format-grade.rkt
+++ b/handin-server/format-grade.rkt
@@ -42,10 +42,11 @@
 ;; Output: an xexpr
 (define (format-grade-details entries)
   (if (list? entries)
-    `((dl ,@(for/list ([entry (in-list entries)]
-                      #:when (string? (first entry))
-                      [child (in-list (list `(dt ,(first entry)) `(dd ,(number->string (second entry)))))])
-             child)))
+    `((table ([class "grading"])
+       ,@(for/list
+                   ([entry (in-list entries)]
+                    #:when (string? (first entry)))
+                    `(tr (td ,(number->string (second entry))) (td ,(first entry))))))
     `()))
 
 ;; compute total grade based on filled grading scheme


### PR DESCRIPTION
Also see ticket https://github.com/ps-tuebingen/info1-teaching-material/issues/12
- Now using tables to display the filled grading scheme.
- Show first the grade then the explanation to ease reading and be consistent with grading scheme on exercise sheets
