### PR TITLE
GUI improvements

### DIFF
--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -185,7 +185,15 @@
        (lambda ()
          (when abort-commit-dialog (send abort-commit-dialog show #f))
          ; Using `'(ok caution)` below is not necessarily right, we should get info from the client.
-         (message-box "Handin" (string-append final-message "\n" intermediate-message) this '(ok caution))
+         (message-box "Handin"
+                      (string-append (if (equal? final-message "Handin successful.")
+                                         ; XXX Translate default message to German.
+                                         "Erfolgreiche Abgabe!"
+                                         final-message)
+                                     "\n"
+                                     intermediate-message)
+                      this
+                      '(ok caution))
          ; This is hacky; final-message has multiple lines,
          ; but only the first will be shown.
          ; You better start your success message with "Handin saved"

--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -114,7 +114,6 @@
             [on-retrieve 'retrieve]
             [else (error 'handin-frame "bad initial values")]))
 
-    (define status #f)
     (define username
       (new text-field%
            [label "Username:"]
@@ -238,7 +237,7 @@
         (when go?
           (custodian-shutdown-all comm-cust)
           (show #f))))
-    (set! status
+    (define status
           (new message%
                [label (format "Making secure connection to ~a..." server)]
                [parent this]

--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -177,8 +177,8 @@
       (queue-callback
        (lambda ()
          (when abort-commit-dialog (send abort-commit-dialog show #f))
-         ; Using `ok` below is not necessarily right, we should get info from the client.
-         (message-box "Handin" final-message this '(ok))
+         ; Using `'(ok caution)` below is not necessarily right, we should get info from the client.
+         (message-box "Handin" final-message this '(ok caution))
          ; This is hacky; final-message has multiple lines,
          ; but only the first will be shown.
          ; You better start your success message with "Handin saved"

--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -273,13 +273,14 @@
                          (set! continue-abort? #t) (send d show #f))))))
 
     (define interface-widgets
-      (list ok username passwd assignment retrieve?))
+      (list ok cancel username passwd assignment retrieve?))
     (define (disable-interface)
       (for ([x (in-list interface-widgets)]) (send x enable #f)))
     (define (enable-interface)
       (for ([x (in-list interface-widgets)]) (send x enable #t) ))
     (define (done-interface)
       (send cancel set-label "Close")
+      (send cancel enable #t)
       (send cancel focus))
 
     (define (report-error tag exn)

--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -158,6 +158,7 @@
 
     (define (submit-file)
       (define final-message "Handin successful.")
+      (define intermediate-message #f)
       (submit-assignment
        connection
        (send username get-value)
@@ -173,12 +174,18 @@
        ;; message/message-final/message-box handlers
        (lambda (msg) (send status set-label msg))
        (lambda (msg) (set! final-message msg))
-       (lambda (msg styles) (message-box "Handin" msg this styles)))
+       (lambda (msg styles)
+         ; XXX This is is a total hack abusing the protocol :-(.
+         (if (equal? styles '(ok caution))
+             (begin
+               (set! intermediate-message msg)
+               'ok)
+             (message-box "Handin" msg this styles))))
       (queue-callback
        (lambda ()
          (when abort-commit-dialog (send abort-commit-dialog show #f))
          ; Using `'(ok caution)` below is not necessarily right, we should get info from the client.
-         (message-box "Handin" final-message this '(ok caution))
+         (message-box "Handin" (string-append final-message "\n" intermediate-message) this '(ok caution))
          ; This is hacky; final-message has multiple lines,
          ; but only the first will be shown.
          ; You better start your success message with "Handin saved"

--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -177,6 +177,12 @@
       (queue-callback
        (lambda ()
          (when abort-commit-dialog (send abort-commit-dialog show #f))
+         ; Using `ok` below is not necessarily right, we should get info from the client.
+         (message-box "Handin" final-message this '(ok))
+         ; This is hacky; final-message has multiple lines,
+         ; but only the first will be shown.
+         ; You better start your success message with "Handin saved"
+         ; or equivalent on the first line.
          (send status set-label final-message)
          (set! committing? #f)
          (done-interface))))


### PR DESCRIPTION
Needs retesting before merge.

Fix ps-tuebingen/info1-teaching-material#7.
Fix ps-tuebingen/info1-teaching-material#49.

To do that, I changed the handin client:
- [x] disable controls for interrupting submission
- [x] show warnings asynchronously without changing the protocol (through a horrible hack, I'll admit).
- [x] show whether the solution is saved at the beginning of the checker message, beyond the status line, as asked here https://github.com/ps-tuebingen/info1-teaching-material/issues/42#issuecomment-152862593
