### PR TITLE
Easy GUI improvements

### DIFF
--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -267,13 +267,14 @@
                          (set! continue-abort? #t) (send d show #f))))))
 
     (define interface-widgets
-      (list ok username passwd assignment retrieve?))
+      (list ok cancel username passwd assignment retrieve?))
     (define (disable-interface)
       (for ([x (in-list interface-widgets)]) (send x enable #f)))
     (define (enable-interface)
       (for ([x (in-list interface-widgets)]) (send x enable #t) ))
     (define (done-interface)
       (send cancel set-label "Close")
+      (send cancel enable #t)
       (send cancel focus))
 
     (define (report-error tag exn)

--- a/handin-client/client-gui.rkt
+++ b/handin-client/client-gui.rkt
@@ -114,7 +114,6 @@
             [on-retrieve 'retrieve]
             [else (error 'handin-frame "bad initial values")]))
 
-    (define status #f)
     (define username
       (new text-field%
            [label "Username:"]
@@ -238,7 +237,7 @@
         (when go?
           (custodian-shutdown-all comm-cust)
           (show #f))))
-    (set! status
+    (define status
           (new message%
                [label (format "Making secure connection to ~a..." server)]
                [parent this]


### PR DESCRIPTION
Fix ps-tuebingen/info1-teaching-material#7.

This simply disables controls for interrupting submission, with code from #16.

A separate PR will cover other changes from #16. I still plan to merge them, but have them separate, so that it's easier to undo them if we ever want.
