### PR TITLE
Implement atomic saving of ATTEMPT

### DIFF
--- a/handin-server/main.rkt
+++ b/handin-server/main.rkt
@@ -164,6 +164,8 @@
   (apply string-append (car users)
          (map (lambda (u) (string-append "+" u)) (cdr users))))
 
+(define HANDIN-NAME "handin")
+
 (define (accept-specific-submission data r r-safe w)
   ;; Note: users are always sorted
   (define users       (a-ref data 'usernames))
@@ -219,7 +221,7 @@
         (when (directory-exists? ATTEMPT-DIR)
           (delete-directory/files ATTEMPT-DIR))
         (make-directory ATTEMPT-DIR)
-        (save-submission s (build-path ATTEMPT-DIR "handin"))
+        (save-submission s (build-path ATTEMPT-DIR HANDIN-NAME))
         (timeout-control 'reset)
         (log-line "checking ~a for ~a" assignment users)
         (let* ([checker* (path->complete-path (build-path 'up "checker.rkt"))]
@@ -263,9 +265,9 @@
                     (begin
                       (log-line "saving ~a for ~a" assignment users)
                       (parameterize ([current-directory ATTEMPT-DIR])
-                        (cond [part (unless (equal? part "handin")
-                                      (rename-file-or-directory "handin" part))]
-                              [(file-exists? "handin") (delete-file "handin")]))
+                        (cond [part (unless (equal? part HANDIN-NAME)
+                                      (rename-file-or-directory HANDIN-NAME part))]
+                              [(file-exists? HANDIN-NAME) (delete-file HANDIN-NAME)]))
                       ;; Shift successful-attempt directories so that there's
                       ;;  no SUCCESS-0:
                       (make-success-dir-available 0)

--- a/handin-server/main.rkt
+++ b/handin-server/main.rkt
@@ -164,6 +164,12 @@
   (apply string-append (car users)
          (map (lambda (u) (string-append "+" u)) (cdr users))))
 
+; Two-step saving:
+; 1. save submission as "ATTEMPT" / HANDIN-NAME-TMP
+; 2. once that's done, rename it (atomically) to "ATTEMPT" / HANDIN-NAME.
+; This way, if "ATTEMPT" / HANDIN-NAME exists, it's complete.
+
+(define HANDIN-NAME-TMP "handin-tmp")
 (define HANDIN-NAME "handin")
 
 (define (accept-specific-submission data r r-safe w)
@@ -221,7 +227,8 @@
         (when (directory-exists? ATTEMPT-DIR)
           (delete-directory/files ATTEMPT-DIR))
         (make-directory ATTEMPT-DIR)
-        (save-submission s (build-path ATTEMPT-DIR HANDIN-NAME))
+        (save-submission s (build-path ATTEMPT-DIR HANDIN-NAME-TMP))
+        (rename-file-or-directory (build-path ATTEMPT-DIR HANDIN-NAME-TMP) (build-path ATTEMPT-DIR HANDIN-NAME))
         (timeout-control 'reset)
         (log-line "checking ~a for ~a" assignment users)
         (let* ([checker* (path->complete-path (build-path 'up "checker.rkt"))]


### PR DESCRIPTION
Right now, if `"SUCCESS-0/handin.rkt"` exists, the whole submission
completed. But we don't have such guarantees for `"ATTEMPT/handin"`,
which might be incomplete and corrupted.

Implement such guarantees as well by a simple two-step saving process:
1. save submission as `"ATTEMPT" / HANDIN-NAME-TMP` (currently
"ATTEMPT/handin-tmp");
2. once that's done, rename it (atomically) to `"ATTEMPT" /
HANDIN-NAME` (currently `"ATTEMPT/handin"`).

This way, if `"ATTEMPT" / HANDIN-NAME` exists, it's complete.

---

Additionally, we might want to change `HANDIN-NAME` to `handin.rkt` for convenience.

And after this, we might want to change the status server to show `ATTEMPT/handin.rkt`, so students can confirm that their submission is safe.
