### PR TITLE
More granular validation of templates and grade files

### DIFF
--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -15,7 +15,7 @@
       (raise-syntax-error source errstr synob)))
 
 ; Syntax helper for checking exercise entry
-(define-for-syntax (check-exercise descr maxp)
+(define-for-syntax (check-exercise descr maxp [unfinished-grading #f])
   (lambda (stx i)
     (let ([tdescr (list-ref descr i)]
           [tmaxp (list-ref maxp i)])
@@ -23,17 +23,19 @@
         [(d p)
          (and
           (check-synobj-satisfies string? #'d 'exercise-entry "description not string")
-          (check-synobj-satisfies exact-integer? #'p 'exercise-entry "points not integer")
-          (check-synobj-satisfies exact-nonnegative-integer? #'p 'exercise-entry "points not >= 0")
           (check-synobj-satisfies (λ (descr-tested) (string=? descr-tested tdescr))
                                   #'d
                                   'exercise-entry
                                   "description doesn't match template")
-
-          (check-synobj-satisfies (λ (points) (<= points tmaxp))
-                                  #'p
-                                  'exercise-entry
-                                  "too many points on exercise"))]))))
+          (or
+           unfinished-grading
+           (and
+           (check-synobj-satisfies exact-integer? #'p 'exercise-entry "points not integer")
+           (check-synobj-satisfies exact-nonnegative-integer? #'p 'exercise-entry "points not >= 0")
+           (check-synobj-satisfies (λ (points) (<= points tmaxp))
+                                   #'p
+                                   'exercise-entry
+                                   "too many points on exercise"))))]))))
 
 (define-for-syntax (grading-finished-entry? stx)
   (syntax-case stx ()

--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -79,7 +79,9 @@
      (and
       (check-synobj-satisfies boolean? #'bool 'grading-finished-entry "not a boolean")
       #'void)]
-    [(_ . args) (raise-syntax-error 'grading-finished-entry "too many arguments" #'args (cdr (syntax->list #'args)))]
+    [(_ arg arg-excess . args)
+     (raise-syntax-error 'grading-finished-entry "too many arguments" stx #'arg-excess)]
+    [(_) (raise-syntax-error 'grading-finished-entry "boolean missing in grading-finished entry" stx)]
     [_ (raise-syntax-error 'grading-finished-entry "incorrect grading-finished entry" stx)]))
 
 ; Macro generating macro checking language

--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -54,11 +54,13 @@
 
 ; Check if the passed grading-finished entry marks the file as complete.
 (define-for-syntax (grading-finished? stx)
-  (syntax-case stx (grading-finished)
-    [(grading-finished bool-syn)
+  (syntax-case stx ()
+    [(id bool-syn)
      (let ([bool (syntax->datum #'bool-syn)])
-       (and (boolean? bool)
-            bool))]
+       (and
+        (symbol=? (syntax->datum #'id) 'grading-finished)
+        (boolean? bool)
+        bool))]
     [_ #false]))
 
 ; List-of Syntax -> List-of String

--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -39,8 +39,7 @@
                                    "too many points on exercise"))))]))))
 
 (define-for-syntax (grading-finished-entry? stx)
-  (syntax-case stx ()
-    [(id _) (symbol=? (syntax->datum #'id) 'grading-finished)]))
+  (symbol=? (first (syntax->datum stx)) 'grading-finished))
 
 ; List-of Syntax -> List-of String
 ; (syntax of the form (string-literal symbol integer-literal))

--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -97,11 +97,12 @@
 
               (define-syntax (gf-module-begin stx)
                 (syntax-case stx ()
-                  [(_ (g-f exrcs (... ...))) (if (grading-finished-entry? #'g-f)
-                                                 (if (= (length (syntax->datum #'(exrcs (... ...)))) #,(length maxp))
-                                                     (when (andmap (check-exercise (list #,@descr) (list #,@maxp) (grading-finished? #'g-f)) (syntax->list #'(exrcs (... ...))) (range #,(length maxp)))
-                                                       #'(#%module-begin (g-f #t)))
-                                                     ; What should the source location be?
-                                                     (raise-syntax-error 'top-level "wrong number of exercise entries"))
-                                                 ; XXX We have a syntax error, but that's imprecise. Where's exactly the problem?
-                                                 (raise-syntax-error 'top-level  "first item not a valid 'grading finished' entry" #'g-f))]))))]))
+                  [(_ (g-f exrcs (... ...)))
+                   (if (grading-finished-entry? #'g-f)
+                       (if (= (length (syntax->datum #'(exrcs (... ...)))) #,(length maxp))
+                           (when (andmap (check-exercise (list #,@descr) (list #,@maxp) (grading-finished? #'g-f)) (syntax->list #'(exrcs (... ...))) (range #,(length maxp)))
+                             #'(#%module-begin (g-f #t)))
+                           ; What should the source location be?
+                           (raise-syntax-error 'top-level "wrong number of exercise entries"))
+                       ; XXX We have a syntax error, but that's imprecise. Where's exactly the problem?
+                       (raise-syntax-error 'top-level  "first item not a valid 'grading finished' entry" #'g-f))]))))]))

--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -100,6 +100,9 @@
           (provide #%app)
           (provide #%top-interaction) ; Allow running REPL from users of `grade-template.rktd`, that is, `grade.rktd` files.
 
+          ; Don't throw out grading-finished entry, but check it.
+          (tg-f)
+
           (define-syntax (gf-module-begin stx)
             (syntax-case stx ()
               [(_ (g-f exrcs (... ...)))

--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -8,6 +8,7 @@
 (provide #%app)
 (provide #%datum)
 (provide #%top-interaction) ; Allow running REPL from `grade-template.rktd`
+(provide grading-finished)
 
 (define-for-syntax (check-synobj-satisfies pred synob source errstr)
   (if (pred (syntax->datum synob))
@@ -53,6 +54,15 @@
   (syntax-case stx ()
     [(d a p) (syntax->datum #'p)]))
 
+(define-syntax (grading-finished stx)
+  (syntax-case stx ()
+    [(_ bool)
+     (and
+      (check-synobj-satisfies boolean? #'bool 'grading-finished-entry "not a boolean")
+      #'void)]
+    [(_ . args) (raise-syntax-error 'grading-finished-entry "too many arguments" #'args (cdr (syntax->list #'args)))]
+    [_ (raise-syntax-error 'grading-finished-entry "incorrect grading-finished entry" stx)]))
+
 ; Macro generating macro checking language
 ; ----------------------------------------
 
@@ -78,10 +88,4 @@
                                                      ; What should the source location be?
                                                      (raise-syntax-error 'top-level "wrong number of exercise entries"))
                                                  ; XXX We have a syntax error, but that's imprecise. Where's exactly the problem?
-                                                 (raise-syntax-error 'top-level  "first item not a valid 'grading finished' entry" #'g-f))]))
-
-              (define-syntax (grading-finished stx)
-                (syntax-case stx ()
-                  [(_ bool) (if (boolean? (syntax->datum #'bool))
-                                #'void
-                                (raise-syntax-error 'grading-finished-entry "not a boolean"))]))))]))
+                                                 (raise-syntax-error 'top-level  "first item not a valid 'grading finished' entry" #'g-f))]))))]))

--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -3,11 +3,12 @@
 (require (for-syntax racket))
 (require (for-syntax racket/base))
 
-(provide (rename-out [gf-def-module-begin #%module-begin]))
-
-(provide #%app)
-(provide #%datum)
-(provide #%top-interaction) ; Allow running REPL from `grade-template.rktd`
+; Define language for grade-template.rktd files as a variant of racket/base
+; with a special #%module-begin, so that running correct files will not
+; produce strange warnings or behaviors.
+(provide
+ (except-out (all-from-out racket/base) #%module-begin)
+ (rename-out [gf-def-module-begin #%module-begin]))
 
 (define-for-syntax (check-satisfies pred synob source errstr)
   (if (pred synob)
@@ -100,11 +101,15 @@
        (begin
          (grading-finished-checker #'tg-f #:is-template #true)
 
+         ; Define language for grade.rktd files as a variant of racket/base
+         ; with a special #%module-begin, so that running correct files will not
+         ; produce strange warnings or behaviors.
          #`(#%module-begin
-            (provide (rename-out [gf-module-begin #%module-begin]))
-            (provide #%datum)
-            (provide #%app)
-            (provide #%top-interaction) ; Allow running REPL from users of `grade-template.rktd`, that is, `grade.rktd` files.
+
+            (require racket/base) ; Needed for the reexport.
+            (provide
+             (except-out (all-from-out racket/base) #%module-begin)
+             (rename-out [gf-module-begin #%module-begin]))
 
             (define-syntax (gf-module-begin stx)
               (syntax-case stx ()

--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -9,23 +9,31 @@
 (provide #%datum)
 (provide #%top-interaction) ; Allow running REPL from `grade-template.rktd`
 
+(define-for-syntax (check-synobj-satisfies pred synob source errstr)
+  (if (pred (syntax->datum synob))
+      #true
+      (raise-syntax-error source errstr synob)))
+
 ; Syntax helper for checking exercise entry
 (define-for-syntax (check-exercise descr maxp)
   (lambda (stx i)
     (let ([tdescr (list-ref descr i)]
           [tmaxp (list-ref maxp i)])
       (syntax-case stx ()
-        [(d p) (if (string? (syntax->datum #'d))
-                   (if (exact-integer? (syntax->datum #'p))
-                       (if (exact-nonnegative-integer? (syntax->datum #'p))
-                           (if (string=? (syntax->datum #'d) tdescr)
-                               (if (<= (syntax->datum #'p) tmaxp)
-                                   #t
-                                   (raise-syntax-error 'exercise-entry "too many points on exercise" #'p))
-                               (raise-syntax-error 'exercise-entry "description doesn't match template" #'d))
-                           (raise-syntax-error 'exercise-entry "points not >= 0" #'p))
-                       (raise-syntax-error 'exercise-entry "points not integer" #'p))
-                   (raise-syntax-error 'exercise-entry "description not string" #'d))]))))
+        [(d p)
+         (and
+          (check-synobj-satisfies string? #'d 'exercise-entry "description not string")
+          (check-synobj-satisfies exact-integer? #'p 'exercise-entry "points not integer")
+          (check-synobj-satisfies exact-nonnegative-integer? #'p 'exercise-entry "points not >= 0")
+          (check-synobj-satisfies (λ (descr-tested) (string=? descr-tested tdescr))
+                                  #'d
+                                  'exercise-entry
+                                  "description doesn't match template")
+
+          (check-synobj-satisfies (λ (points) (<= points tmaxp))
+                                  #'p
+                                  'exercise-entry
+                                  "too many points on exercise"))]))))
 
 (define-for-syntax (grading-finished-entry? stx)
   (syntax-case stx ()

--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -91,27 +91,27 @@
      (let* ([stxlist (syntax->list #'(texrcs ...))]
             [descr (map description stxlist)]
             [maxp (map maxpoints stxlist)])
-           #`(#%module-begin
-              (provide (rename-out [gf-module-begin #%module-begin]))
-              (provide grading-finished)
-              (provide #%datum)
-              (provide #%app)
-              (provide #%top-interaction) ; Allow running REPL from users of `grade-template.rktd`, that is, `grade.rktd` files.
+       #`(#%module-begin
+          (provide (rename-out [gf-module-begin #%module-begin]))
+          (provide grading-finished)
+          (provide #%datum)
+          (provide #%app)
+          (provide #%top-interaction) ; Allow running REPL from users of `grade-template.rktd`, that is, `grade.rktd` files.
 
-              (define-syntax (gf-module-begin stx)
-                (syntax-case stx ()
-                  [(_ (g-f exrcs (... ...)))
-                   (and
-                    (check-satisfies grading-finished-entry?
-                                     #'g-f
-                                     ; XXX We have a syntax error, but that's imprecise. Where's exactly the problem?
-                                     'top-level
-                                     "first item not a valid 'grading finished' entry")
-                    (if (= (length (syntax->datum #'(exrcs (... ...)))) #,(length maxp))
-                        (when (andmap
-                               (check-exercise (list #,@descr) (list #,@maxp) (grading-finished? #'g-f))
-                               (syntax->list #'(exrcs (... ...)))
-                               (range #,(length maxp)))
-                          #'(#%module-begin (g-f #t)))
-                        ; What should the source location be?
-                        (raise-syntax-error 'top-level "wrong number of exercise entries")))]))))]))
+          (define-syntax (gf-module-begin stx)
+            (syntax-case stx ()
+              [(_ (g-f exrcs (... ...)))
+               (and
+                (check-satisfies grading-finished-entry?
+                                 #'g-f
+                                 ; XXX We have a syntax error, but that's imprecise. Where's exactly the problem?
+                                 'top-level
+                                 "first item not a valid 'grading finished' entry")
+                (if (= (length (syntax->datum #'(exrcs (... ...)))) #,(length maxp))
+                    (when (andmap
+                           (check-exercise (list #,@descr) (list #,@maxp) (grading-finished? #'g-f))
+                           (syntax->list #'(exrcs (... ...)))
+                           (range #,(length maxp)))
+                      #'(#%module-begin (g-f #t)))
+                    ; What should the source location be?
+                    (raise-syntax-error 'top-level "wrong number of exercise entries")))]))))]))

--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -75,16 +75,22 @@
   (syntax-case stx ()
     [(d a p) (syntax->datum #'p)]))
 
-(define-syntax (grading-finished stx)
+(define-for-syntax (grading-finished-checker stx is-template)
   (syntax-case stx ()
     [(_ bool)
      (and
       (check-synobj-satisfies boolean? #'bool 'grading-finished-entry "not a boolean")
+      (or (not is-template)
+          (check-synobj-satisfies false? #'bool 'grading-finished-entry
+                                  "grading-finished entry must be #false in template"))
       #'(void))]
     [(_ arg arg-excess . args)
      (raise-syntax-error 'grading-finished-entry "too many arguments" stx #'arg-excess)]
     [(_) (raise-syntax-error 'grading-finished-entry "boolean missing in grading-finished entry" stx)]
     [_ (raise-syntax-error 'grading-finished-entry "incorrect grading-finished entry" stx)]))
+
+(define-syntax (grading-finished stx)
+  (grading-finished-checker stx #true))
 
 ; Macro generating macro checking language
 ; ----------------------------------------
@@ -121,4 +127,7 @@
                            (range #,(length maxp)))
                       #'(#%module-begin g-f))
                     ; What should the source location be?
-                    (raise-syntax-error 'top-level "wrong number of exercise entries")))]))))]))
+                    (raise-syntax-error 'top-level "wrong number of exercise entries")))]))
+
+          (define-syntax (grading-finished stx)
+            (grading-finished-checker stx #false))))]))

--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -108,7 +108,8 @@
           (provide #%app)
           (provide #%top-interaction) ; Allow running REPL from users of `grade-template.rktd`, that is, `grade.rktd` files.
 
-          ; Don't throw out grading-finished entry, but check it.
+          ; Don't throw out grading-finished entry, but output it, so that
+          ; calling `grading-finished` will check it.
           tg-f
 
           (define-syntax (gf-module-begin stx)
@@ -125,7 +126,10 @@
                            (check-exercise (list #,@descr) (list #,@maxp) (grading-finished? #'g-f))
                            (syntax->list #'(exrcs (... ...)))
                            (range #,(length maxp)))
-                      #'(#%module-begin g-f))
+                      #'(#%module-begin
+                         ; Don't throw out grading-finished entry, but output
+                         ; it, so that calling `grading-finished` will check it.
+                         g-f))
                     ; What should the source location be?
                     (raise-syntax-error 'top-level "wrong number of exercise entries")))]))
 

--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -74,7 +74,7 @@
   (syntax-case stx ()
     [(d a p) (syntax->datum #'p)]))
 
-(define-for-syntax (grading-finished-checker stx is-template)
+(define-for-syntax (grading-finished-checker stx #:is-template is-template)
   (syntax-case stx ()
     [(_ bool)
      (and
@@ -98,7 +98,7 @@
             [descr (map description stxlist)]
             [maxp (map maxpoints stxlist)])
        (begin
-         (grading-finished-checker #'tg-f #true)
+         (grading-finished-checker #'tg-f #:is-template #true)
 
          #`(#%module-begin
             (provide (rename-out [gf-module-begin #%module-begin]))
@@ -115,7 +115,7 @@
                                    ; XXX We have a syntax error, but that's imprecise. Where's exactly the problem?
                                    'top-level
                                    "first item not a valid 'grading finished' entry")
-                  (grading-finished-checker #'g-f #false)
+                  (grading-finished-checker #'g-f #:is-template #false)
                   (if (= (length (syntax->datum #'(exrcs (... ...)))) #,(length maxp))
                       (when (andmap
                              (check-exercise (list #,@descr) (list #,@maxp) (grading-finished? #'g-f))

--- a/handin-server/grade-template.rkt
+++ b/handin-server/grade-template.rkt
@@ -78,7 +78,7 @@
     [(_ bool)
      (and
       (check-synobj-satisfies boolean? #'bool 'grading-finished-entry "not a boolean")
-      #'void)]
+      #'(void))]
     [(_ arg arg-excess . args)
      (raise-syntax-error 'grading-finished-entry "too many arguments" stx #'arg-excess)]
     [(_) (raise-syntax-error 'grading-finished-entry "boolean missing in grading-finished entry" stx)]
@@ -101,7 +101,7 @@
           (provide #%top-interaction) ; Allow running REPL from users of `grade-template.rktd`, that is, `grade.rktd` files.
 
           ; Don't throw out grading-finished entry, but check it.
-          (tg-f)
+          tg-f
 
           (define-syntax (gf-module-begin stx)
             (syntax-case stx ()
@@ -117,6 +117,6 @@
                            (check-exercise (list #,@descr) (list #,@maxp) (grading-finished? #'g-f))
                            (syntax->list #'(exrcs (... ...)))
                            (range #,(length maxp)))
-                      #'(#%module-begin (g-f #t)))
+                      #'(#%module-begin g-f))
                     ; What should the source location be?
                     (raise-syntax-error 'top-level "wrong number of exercise entries")))]))))]))


### PR DESCRIPTION
WIP.
- [x] I don't like how checking for `grading-finished` is implemented (that is, by making it a macro).
  @lordxist , was there a reason I'm missing why you did it that way? I've changed that
- [x] `grading-finished-checker` and callers of `grading-finished-entry?` should still be consolidated.

Fix ps-tuebingen/info1-teaching-material#92.
Also, now we avoid producing uninformative "bad syntax" errors.
And finally, we force templates to be marked as incomplete.
